### PR TITLE
Using slug instead of id for folder name

### DIFF
--- a/src/EditorFieldTypeStorage.php
+++ b/src/EditorFieldTypeStorage.php
@@ -79,7 +79,7 @@ class EditorFieldTypeStorage
          */
         $slug      = $entry->getStreamSlug();
         $namespace = $entry->getStreamNamespace();
-        $directory = $entry->getEntryId();
+        $directory = $entry->getAttribute('slug');
 
         return "{$namespace}/{$slug}/{$directory}";
     }


### PR DESCRIPTION
I'm sure, it would be much more conveniently for the user.
