### PR TITLE
Remove time modified restriction when in production.

### DIFF
--- a/src/Command/SyncFile.php
+++ b/src/Command/SyncFile.php
@@ -77,6 +77,7 @@ class SyncFile
          * has been updated, so write the content to the file.
          */
         if (!$config->get('app.debug')) {
+
             $this->dispatch(new PutFile($this->fieldType));
 
             $content = array_get($entry->getAttributes(), $this->fieldType->getField());
@@ -87,7 +88,9 @@ class SyncFile
          * since that is what we use anyways.
          */
         if (filemtime($path) < $entry->lastModified()->timestamp) {
+
             $this->dispatch(new PutFile($this->fieldType));
+           
             $content = array_get($entry->getAttributes(), $this->fieldType->getField());
         }
 

--- a/src/Command/SyncFile.php
+++ b/src/Command/SyncFile.php
@@ -73,11 +73,10 @@ class SyncFile
         }
 
         /**
-         * If the file is newer and we're NOT debugging
-         * then update with the file with the database.
+         * If we're NOT debugging and we got this far then we know that the content
+         * has been updated, so write the content to the file.
          */
-        if (filemtime($path) > $entry->lastModified()->timestamp && !$config->get('app.debug')) {
-
+        if (!$config->get('app.debug')) {
             $this->dispatch(new PutFile($this->fieldType));
 
             $content = array_get($entry->getAttributes(), $this->fieldType->getField());
@@ -88,9 +87,7 @@ class SyncFile
          * since that is what we use anyways.
          */
         if (filemtime($path) < $entry->lastModified()->timestamp) {
-
             $this->dispatch(new PutFile($this->fieldType));
-
             $content = array_get($entry->getAttributes(), $this->fieldType->getField());
         }
 


### PR DESCRIPTION
This makes it so that you don't have to save twice for changes to show up in the admin.

I tested that this works in the following ways:
Update admin (db) and note that it does update file. (APP_DEBUG=true)
Update file and note that it does update the DB. (APP_DEBUG=true)
Update file and note that it does NOT update the DB, but reverts the file to the content in the DB. (APP_DEBUG=false)
Update the admin (DB) and note that it does update the file on the FS.

Also in APP_DEBUG=false I checked that if I change the FS and load the page in the front-end then the file will be replaced with the content from the DB.