### PR TITLE
Fix editor init when multiple instances are loaded through ajax

### DIFF
--- a/resources/js/input.js
+++ b/resources/js/input.js
@@ -87,7 +87,10 @@ CodeMirror.defineMode("twig_html", function (config) {
 
             emmetCodeMirror(editor);
 
-            // The CodeMirror div is created immediately after the textarea
+            /**
+             * The CodeMirror div is created
+             * immediately after the textarea.
+             */
             let cm = textarea.parentElement.querySelector('.CodeMirror');
             let cmScroll = cm.querySelector('.CodeMirror-scroll');
 

--- a/resources/js/input.js
+++ b/resources/js/input.js
@@ -21,8 +21,9 @@ CodeMirror.defineMode("twig_html", function (config) {
      */
     setTimeout(function () {
 
+        // Find uninitialised editors (i.e. not existing ones if loading through ajax)
         let editors = document.querySelectorAll(
-            'textarea[data-provides="anomaly.field_type.editor"]'
+            'textarea[data-provides="anomaly.field_type.editor"]:not([data-editor-init])'
         );
 
         editors.forEach(function (textarea) {
@@ -86,8 +87,9 @@ CodeMirror.defineMode("twig_html", function (config) {
 
             emmetCodeMirror(editor);
 
-            let cm = document.querySelector('.CodeMirror');
-            let cmScroll = document.querySelector('.CodeMirror-scroll');
+            // The CodeMirror div is created immediately after the textarea
+            let cm = textarea.parentElement.querySelector('.CodeMirror');
+            let cmScroll = cm.querySelector('.CodeMirror-scroll');
 
             cm.style.height = 'auto';
             cm.style.minHeight = height;
@@ -108,6 +110,9 @@ CodeMirror.defineMode("twig_html", function (config) {
             $('a[data-toggle="tab"]').on('shown.bs.tab', function () {
                 editor.refresh();
             });
+
+            // Mark this editor as initialised
+            textarea.setAttribute('data-editor-init', true);
         });
     }, 10);
 


### PR DESCRIPTION
Previously the existing editors would be duplicated and the styles would only be applied to the first editor on the page.